### PR TITLE
Added 2 new ConfigurationRepository implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,22 @@
         <slf4j.version>1.7.12</slf4j.version>
         <mockito.version>1.10.19</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <awssdk.version>1.11.25</awssdk.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
-
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -119,6 +130,18 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
 
         <!-- Google -->

--- a/src/main/java/org/zalando/baigan/etcd/service/EtcdClient.java
+++ b/src/main/java/org/zalando/baigan/etcd/service/EtcdClient.java
@@ -16,18 +16,16 @@
 
 package org.zalando.baigan.etcd.service;
 
-import java.io.IOException;
-import java.net.URL;
-
-import javax.annotation.Nonnull;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.baigan.etcd.model.KeyResultNode;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.base.Optional;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
 
 /**
  * @author mchand
@@ -53,12 +51,12 @@ public final class EtcdClient {
                     KeyResultNode.class);
             final String response = resultNode.getNode().getValue();
 
-            return Optional.fromNullable(response);
+            return Optional.ofNullable(response);
         } catch (IOException e) {
             LOG.warn("There was an exception trying to get key: " + key, e);
         } catch (NullPointerException npe) {
             LOG.warn("There was an exception trying to get key: " + key);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
+++ b/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This class provides a concrete implementation for the Method invocation
@@ -101,7 +102,7 @@ public class ContextAwareConfigurationMethodInvocationHandler
 
     private Object getConfig(final String key) {
 
-        java.util.Optional<Configuration<?>> optional = configurationRepository.get(key);
+        final Optional<Configuration> optional = configurationRepository.get(key);
         if (!optional.isPresent()) {
             return null;
         }

--- a/src/main/java/org/zalando/baigan/service/AbstractConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/AbstractConfigurationRepository.java
@@ -3,37 +3,39 @@ package org.zalando.baigan.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.baigan.model.Configuration;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public abstract class AbstractConfigurationRepository implements ConfigurationRepository {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractConfigurationRepository.class);
 
-    protected ObjectMapper objectMapper = new ObjectMapper().registerModule(new GuavaModule());
+    ObjectMapper objectMapper = new ObjectMapper().registerModule(new GuavaModule());
 
-    protected Optional<Configuration<?>> getConfiguration(final String text) {
+    @Nonnull
+    protected Optional<Configuration> getConfiguration(final String text) {
         try {
-            return Optional.<Configuration<?>>of(objectMapper.readValue(text, Configuration.class));
+            return Optional.of(objectMapper.readValue(text, Configuration.class));
         } catch (IOException e) {
-            LOG.warn(
-                    "Cannot deserialize the Configuration value into Java object.");
+            LOG.warn("Cannot deserialize the Configuration value into Java object.");
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
-    protected List<Configuration> getConfigurations(final String text) {
+    @Nonnull
+    List<Configuration> getConfigurations(final String text) {
         try {
             return objectMapper.readValue(text, new TypeReference<List<Configuration>>() {
             });
         } catch (IOException e) {
-            LOG.warn("Cannot deserialize the Configuration value into Java object.");
+            LOG.warn("Cannot deserialize the Configuration blob into Java objects.");
         }
         return ImmutableList.of();
     }

--- a/src/main/java/org/zalando/baigan/service/ChainedConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/ChainedConfigurationRepository.java
@@ -1,0 +1,56 @@
+package org.zalando.baigan.service;
+
+import com.google.common.collect.ImmutableList;
+import org.zalando.baigan.model.Configuration;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The ChainedConfigurationRepository provides a {@link ConfigurationRepository} that chains multiple configuration
+ * repositories allowing you to fallback to the next repository when the higher order repositories fail to provide
+ * a configuration value.
+ * <p>
+ * The first configuration repository will always be the first one to provide the value. In case it doesn't, this
+ * configuration repository will advance to the next and repeat the attempt. It will continue to do so until it finds
+ * a value or all the repositories failed.
+ */
+public class ChainedConfigurationRepository implements ConfigurationRepository {
+    private final List<ConfigurationRepository> configurationRepositories;
+
+    public ChainedConfigurationRepository(@Nonnull final ConfigurationRepository firstRepository,
+                                          @Nonnull final ConfigurationRepository secondRepository,
+                                          final ConfigurationRepository... moreRepositories) {
+        checkNotNull(firstRepository, "firstRepository is required");
+        checkNotNull(secondRepository, "secondRepository is required");
+
+        ImmutableList.Builder<ConfigurationRepository> builder = ImmutableList.builder();
+        builder.add(firstRepository);
+        builder.add(secondRepository);
+        if (moreRepositories != null && moreRepositories.length > 0) {
+            builder.addAll(Arrays.asList(moreRepositories));
+        }
+        configurationRepositories = builder.build();
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Configuration> get(@Nonnull String key) {
+        for (final ConfigurationRepository configurationRepository : configurationRepositories) {
+            final Optional<Configuration> configuration = configurationRepository.get(key);
+            if (configuration.isPresent()) {
+                return configuration;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void put(@Nonnull String key, @Nonnull String value) {
+
+    }
+}

--- a/src/main/java/org/zalando/baigan/service/ConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/ConfigurationRepository.java
@@ -19,16 +19,12 @@ public interface ConfigurationRepository {
      */
     @Nonnull
     @Deprecated
-    Optional<Configuration<?>> getConfig(@Nonnull final String key);
+    default Optional<Configuration> getConfig(@Nonnull final String key) {
+        return get(key).map(Optional::of).orElse(Optional.absent());
+    }
 
     @Nonnull
-    default java.util.Optional<Configuration<?>> get(@Nonnull final String key) {
-        final Optional<Configuration<?>> config = getConfig(key);
-        if (config.isPresent()) {
-            return java.util.Optional.of(config.get());
-        }
-        return java.util.Optional.empty();
-    }
+    java.util.Optional<Configuration> get(@Nonnull final String key);
 
     void put(@Nonnull final String key, @Nonnull final String value);
 

--- a/src/main/java/org/zalando/baigan/service/EtcdConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/EtcdConfigurationRepository.java
@@ -1,7 +1,6 @@
 package org.zalando.baigan.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +9,7 @@ import org.zalando.baigan.model.Configuration;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -50,12 +50,11 @@ public class EtcdConfigurationRepository extends AbstractConfigurationRepository
     }
 
     @Nonnull
-    public Optional<Configuration<?>> getConfig(@Nonnull final String key) {
+    public Optional<Configuration> get(@Nonnull final String key) {
         try {
             checkArgument(!Strings.isNullOrEmpty(key),
                     "Attempt to get configuration for an empty key !");
-            final Optional<String> optionalConfig = etcdClient
-                    .get(CONFIG_PATH_PREFIX + key);
+            final Optional<String> optionalConfig = etcdClient.get(CONFIG_PATH_PREFIX + key);
 
             if (optionalConfig.isPresent()) {
                 return Optional.of(objectMapper.readValue(optionalConfig.get(),
@@ -65,6 +64,6 @@ public class EtcdConfigurationRepository extends AbstractConfigurationRepository
         } catch (IOException e) {
             LOG.warn("Error while loading configuration for key: " + key, e);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/zalando/baigan/service/FileSystemConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/FileSystemConfigurationRepository.java
@@ -1,6 +1,5 @@
 package org.zalando.baigan.service;
 
-import com.google.common.base.Optional;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -17,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -26,8 +26,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author mchand
  */
-public class FileSystemConfigurationRepository
-        extends AbstractConfigurationRepository {
+public class FileSystemConfigurationRepository extends AbstractConfigurationRepository {
 
     private final LoadingCache<String, Map<String, Configuration>> cachedConfigurations;
     private final String fileName;
@@ -60,7 +59,7 @@ public class FileSystemConfigurationRepository
                     public ListenableFuture<Map<String, Configuration>> reload(
                             String key, Map<String, Configuration> oldValue)
                             throws Exception {
-                        LOG.info("Reloading the configuration from file: " + key);
+                        LOG.info("Reloading the configuration from file {}", key);
                         return super.reload(key, oldValue);
                     }
                 });
@@ -68,15 +67,13 @@ public class FileSystemConfigurationRepository
 
     @Nonnull
     @Override
-    public Optional<Configuration<?>> getConfig(@Nonnull String key) {
+    public Optional<Configuration> get(@Nonnull String key) {
         try {
-            return Optional
-                    .fromNullable(cachedConfigurations.get(fileName).get(key));
+            return Optional.ofNullable(cachedConfigurations.get(fileName).get(key));
         } catch (ExecutionException e) {
-            LOG.warn("Exception while trying to get configuration for key "
-                    + key, e);
+            LOG.warn("Exception while trying to get configuration for key {}", key, e);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/zalando/baigan/service/S3ConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/S3ConfigurationRepository.java
@@ -81,7 +81,13 @@ public class S3ConfigurationRepository extends AbstractConfigurationRepository {
 
     private void setupRefresh() {
         final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-        executor.scheduleAtFixedRate(this::loadConfigurations, this.refreshInterval, this.refreshInterval,
+        executor.scheduleAtFixedRate(() -> {
+                    try {
+                        loadConfigurations();
+                    } catch (RuntimeException e) {
+                        LOG.warn("Failed to refresh S3 configuration", e);
+                    }
+                }, this.refreshInterval, this.refreshInterval,
                 TimeUnit.SECONDS);
     }
 

--- a/src/main/java/org/zalando/baigan/service/S3ConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/S3ConfigurationRepository.java
@@ -37,7 +37,7 @@ public class S3ConfigurationRepository extends AbstractConfigurationRepository {
      * It refreshes configurations using the default refresh interval (60 seconds)
      *
      * @param bucketName The name of the bucket
-     * @param key        The object key, usually, the "ull path" to the JSON file stored in the bucket
+     * @param key        The object key, usually, the "full path" to the JSON file stored in the bucket
      */
     public S3ConfigurationRepository(@Nonnull final String bucketName, @Nonnull final String key) {
         this(bucketName, key, DEFAULT_REFRESH_INTERVAL);
@@ -47,7 +47,7 @@ public class S3ConfigurationRepository extends AbstractConfigurationRepository {
      * Provides a {@link ConfigurationRepository} that reads configurations from a JSON file stored in a S3 bucket.
      *
      * @param bucketName      The name of the bucket
-     * @param key             The object key, usually, the "ull path" to the JSON file stored in the bucket
+     * @param key             The object key, usually, the "full path" to the JSON file stored in the bucket
      * @param refreshInterval The interval, in seconds, to refresh the configurations. A value of 0 disables refreshing
      *                        <p>
      *                        {@see #S3ConfigurationRepository(String, String)}

--- a/src/main/java/org/zalando/baigan/service/S3ConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/S3ConfigurationRepository.java
@@ -1,0 +1,98 @@
+package org.zalando.baigan.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zalando.baigan.model.Configuration;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class S3ConfigurationRepository extends AbstractConfigurationRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(S3ConfigurationRepository.class);
+
+    /**
+     * The default refresh interval which is 60 seconds
+     */
+    private static final long DEFAULT_REFRESH_INTERVAL = 60;
+
+
+    private final AmazonS3 s3Client;
+    private final String bucketName;
+    private final String key;
+    private long refreshInterval = DEFAULT_REFRESH_INTERVAL;
+    private volatile Map<String, Configuration> configurationsMap = ImmutableMap.of();
+
+    /**
+     * Provides a {@link ConfigurationRepository} that reads configurations from a JSON file stored in a S3 bucket.
+     * It refreshes configurations using the default refresh interval (60 seconds)
+     *
+     * @param bucketName The name of the bucket
+     * @param key        The object key, usually, the "ull path" to the JSON file stored in the bucket
+     */
+    public S3ConfigurationRepository(@Nonnull final String bucketName, @Nonnull final String key) {
+        this(bucketName, key, DEFAULT_REFRESH_INTERVAL);
+    }
+
+    /**
+     * Provides a {@link ConfigurationRepository} that reads configurations from a JSON file stored in a S3 bucket.
+     *
+     * @param bucketName      The name of the bucket
+     * @param key             The object key, usually, the "ull path" to the JSON file stored in the bucket
+     * @param refreshInterval The interval, in seconds, to refresh the configurations. A value of 0 disables refreshing
+     *                        <p>
+     *                        {@see #S3ConfigurationRepository(String, String)}
+     */
+    public S3ConfigurationRepository(@Nonnull final String bucketName, @Nonnull final String key, final long refreshInterval) {
+        checkNotNull(bucketName, "bucketName is required");
+        checkNotNull(key, "key is required");
+        checkArgument(refreshInterval >= 0, "refreshInterval has to be >= 0");
+
+        this.bucketName = bucketName;
+        this.key = key;
+        this.refreshInterval = refreshInterval;
+
+        s3Client = new AmazonS3Client();
+        loadConfigurations();
+
+        if (refreshInterval > 0) {
+            setupRefresh();
+        }
+    }
+
+    private void loadConfigurations() {
+        final String configurationText = s3Client.getObjectAsString(bucketName, key);
+        final List<Configuration> configurations = getConfigurations(configurationText);
+        final ImmutableMap.Builder<String, Configuration> builder = ImmutableMap.builder();
+        for (final Configuration configuration : configurations) {
+            builder.put(configuration.getAlias(), configuration);
+        }
+        configurationsMap = builder.build();
+    }
+
+    private void setupRefresh() {
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.scheduleAtFixedRate(this::loadConfigurations, this.refreshInterval, this.refreshInterval,
+                TimeUnit.SECONDS);
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Configuration> get(@Nonnull String key) {
+        return Optional.ofNullable(configurationsMap.get(key));
+    }
+
+    @Override
+    public void put(@Nonnull String key, @Nonnull String value) {
+        throw new UnsupportedOperationException("The S3ConfigurationRepository doesn't allow any changes.");
+    }
+}

--- a/src/main/java/org/zalando/baigan/service/github/GitConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/github/GitConfigurationRepository.java
@@ -1,6 +1,5 @@
 package org.zalando.baigan.service.github;
 
-import com.google.common.base.Optional;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
@@ -10,6 +9,7 @@ import org.zalando.baigan.service.AbstractConfigurationRepository;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -19,13 +19,11 @@ import java.util.concurrent.TimeUnit;
  *
  * @author mchand
  */
-public class GitConfigurationRepository
-        extends AbstractConfigurationRepository {
+public class GitConfigurationRepository extends AbstractConfigurationRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(GitConfigurationRepository.class);
 
     private final LoadingCache<String, Map<String, Configuration>> cachedConfigurations;
     private final GitConfig gitConfig;
-    private Logger LOG = LoggerFactory
-            .getLogger(GitConfigurationRepository.class);
 
     public GitConfigurationRepository(long refreshIntervalInMinutes, GitConfig gitConfig) {
         this.gitConfig = gitConfig;
@@ -36,15 +34,13 @@ public class GitConfigurationRepository
 
     @Nonnull
     @Override
-    public Optional<Configuration<?>> getConfig(@Nonnull String key) {
+    public Optional<Configuration> get(@Nonnull String key) {
         try {
-            return Optional.fromNullable(cachedConfigurations
-                    .get(gitConfig.getSourceFile()).get(key));
+            return Optional.ofNullable(cachedConfigurations.get(gitConfig.getSourceFile()).get(key));
         } catch (ExecutionException e) {
-            LOG.warn("Exception while trying to get configuration for key "
-                    + key, e);
+            LOG.warn("Exception while trying to get configuration for key {}", key, e);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/java/org/zalando/baigan/context/SpringTestContext.java
+++ b/src/test/java/org/zalando/baigan/context/SpringTestContext.java
@@ -1,6 +1,5 @@
 package org.zalando.baigan.context;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +8,7 @@ import org.zalando.baigan.service.ConditionsProcessor;
 import org.zalando.baigan.service.ConfigurationRepository;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -31,11 +31,11 @@ class SpringTestContext {
             }
 
             @Nonnull
-            public Optional<org.zalando.baigan.model.Configuration<?>> getConfig(@Nonnull String key) {
+            public Optional<org.zalando.baigan.model.Configuration> get(@Nonnull String key) {
                 if (KEY.equalsIgnoreCase(key)) {
                     return Optional.of(mockConfiguration(key));
                 } else {
-                    return Optional.absent();
+                    return Optional.empty();
                 }
 
             }


### PR DESCRIPTION
A S3ConfigurationRepository that read configurations from an S3 object with optional background refresh

A ChainedConfigurationRepository that wraps multiple configuration repositories allowing fallback scenarios

Also refactored the base interface ConfigurationRepository to use Java's Optional deprecating the Guava Optional

This closes #14 and requires https://github.com/zalando/baigan-config/pull/12